### PR TITLE
feat: array value support & conjure shared config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ tags:
 
 groups:
   - id: conjure<production>
-    values:
+    items:
       - id: secret
         value: productionsecret
   
   - id: conjure<development>
-    values:
+    items:
       - id: secret
         value: developmentsecret
 ```
@@ -72,30 +72,40 @@ tags:
 
 groups:
   - id: conjure<production>
-    values:
+    items:
       - id: host
         value: 0.0.0.0
       - id: port
         value: 8753
   
   - id: conjure<development>
-    values:
+    items:
       - id: host
         value: 127.0.0.1
       - id: port
         value: 8080
 
   - id: conjure
-    values:
+    items:
       - id: host
         value: 193.241.344.111
       - id: port
         value: 64356
 ```
 
+`conjure-alt.yml` is a `conjure` holding alternative configs
+```yaml
+inherit: conjure.yml
+
+files:
+  - id: config-alt
+    path: templates/config.yml # using the same template
+    output: <tags> # also using the same tags
+```
+
 `config.yml` is your `template` structure
 ```yaml
-host: ${conjure.host}
+host: ${conjure.host|conjure-alt.host}
 port: ${conjure.port}
 secret: ${conjure.secret}
 ```

--- a/example/conjure-alt.yml
+++ b/example/conjure-alt.yml
@@ -1,0 +1,16 @@
+files:
+  - id: config-alt
+    path: example/templates/config.yml # using the same template
+    output: <tags>/config.alt.yml # also using the same tags with a different file name
+    
+tags:
+  - id: production
+    path: example/output/config.production.yml
+
+groups:
+  - id: conjure-alt<production>
+    items:
+      - id: host
+        value: 192.131.31.232
+      - id: port
+        value: 10000

--- a/example/conjure.yml
+++ b/example/conjure.yml
@@ -26,6 +26,11 @@ groups:
         value: 0.0.0.0
       - id: port
         value: 8753
+      - id: many_items
+        value:
+          - item1
+          - item2
+          - item3
   
   - id: conjure<development>
     items:

--- a/example/templates/config.yml
+++ b/example/templates/config.yml
@@ -1,3 +1,4 @@
-host: ${conjure.host}
+host: ${conjure.host|conjure-alt.host}
 port: ${conjure.port}
 secret: ${conjure.secret}
+many-items: ${conjure.many_items}

--- a/internal/conjure_util.go
+++ b/internal/conjure_util.go
@@ -85,3 +85,13 @@ func FromGOB64(str string) (interface{}, error) {
 
 	return config, nil
 }
+
+func GetBytes(val interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	err := enc.Encode(val)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,10 @@ func load(conjureFile string) error {
 
 	h, err = h.BuildConjureFile()
 
+	if err != nil {
+		return err
+	}
+
 	c, err := conjure.New(h)
 
 	if err != nil {

--- a/pkg/handler/filehandler.go
+++ b/pkg/handler/filehandler.go
@@ -33,7 +33,7 @@ type ConjureGroups struct {
 	Id    string `koanf:"id" validate:"required"`
 	Items []struct {
 		Id    string `koanf:"id" validate:"required"`
-		Value string `koanf:"value" validate:"required"`
+		Value interface{} `koanf:"value" validate:"required"`
 	} `koanf:"items"`
 }
 


### PR DESCRIPTION
Add array support to conjure files

```yml

groups:
  - id: some-prop
    items:
      - id: key
        value: 
          - value1
          - value2
          - value3

```

Also added shared config support

```yml
host: ${conjure.host|conjure-alt.host}
```